### PR TITLE
Redirect to entradas on gabimusic variations

### DIFF
--- a/script.js
+++ b/script.js
@@ -129,7 +129,7 @@ function validateAnswer() {
     const currentQuestion = questions[currentQuestionIndex];
 
     // Atajo: si en la primera pregunta escriben "gabimusic" (en cualquier variante), ir directo a entradas
-    if (currentQuestionIndex === 0 && normalizedAnswer === 'gabimusic') {
+    if (currentQuestionIndex === 0 && normalizedAnswer.includes('gabimusic')) {
         showScreen('tickets');
         return;
     }


### PR DESCRIPTION
Add a shortcut to navigate directly to the 'entradas' (tickets) section when 'gabimusic' (or its variations) is entered in the first question.

---
<a href="https://cursor.com/background-agent?bcId=bc-45a475b9-78f9-49bc-957c-6fe3ab2cc0af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45a475b9-78f9-49bc-957c-6fe3ab2cc0af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

